### PR TITLE
added a fix to your SerializableClosure class 

### DIFF
--- a/SerializableClosure.php
+++ b/SerializableClosure.php
@@ -57,10 +57,51 @@ class SerializableClosure implements Serializable {
 		{
 			$code .= $file->current();
 			$file->next();
-		}
+		}		
 		$begin = strpos($code, 'function');
-		$end   = strrpos($code, '}');
-		$code  = substr($code, $begin, $end - $begin + 1);
-		return $code;
+		$index = strpos($code, '{', $begin);
+		$bracketCount = 1;
+		$inString = false;
+		$escape = false;
+		while($bracketCount) {
+			$index++;
+			$char = $code[$index];
+			
+			if($inString && $char == '\\') {
+				$escape = !$escape;
+				continue;
+			}
+			
+			if($escape) {
+				$escape = false;
+				continue;
+			}
+			
+			if($char == '"' || $char == "'") {
+				if(!$inString) {
+					$inString = $char;
+					continue;
+				}
+				
+				if($inString == $char) {
+					$inString = false;
+					continue;
+				}
+			}
+			
+			if($inString) { 
+				continue;
+			}
+			
+			if($code[$index] == '{') {
+				$bracketCount++;
+			} 
+			
+			if($code[$index] == '}') {
+				$bracketCount--;
+			}
+		}
+		
+		return substr($code, $begin, $index - $begin + 1);
 	}
 }


### PR DESCRIPTION
fix to SerializableClosure to allow for edge case where } is on same line as closing } of function e.g. in another block. 

My test case for this is: 

```
if(true) { $func = function ( Apple $a, Bat $b) {
    $rat = 'Cat';
    $dog = 'Doggy';
    if($a->rabbit()) {
        return "cat}}}\"}'''''\\\\\\}}}}{{{{}}}}";
    } else {
        return function(Apple $a) use($b) {
            return $b->$a();
        };
    }
};}
```

I apologize for the nonsensical code example, that's just how I roll. I realize my modification is quite a bit more verbose than the strrpos but I needed such capability so I figured I'd share it with you! 
