### PR TITLE
Allow multiple serialize/unserialize runs

### DIFF
--- a/tests/Jeremeamia/SuperClosure/Test/SerializableClosureTest.php
+++ b/tests/Jeremeamia/SuperClosure/Test/SerializableClosureTest.php
@@ -60,10 +60,10 @@ class SerializableClosureTest extends \PHPUnit_Framework_TestCase
             return ($n <= 1) ? 1 : $n * $factorial($n - 1);
         });
 
-        $returnValue = call_user_func($factorial, 5);
-        $newReturnValue = call_user_func(unserialize(serialize($factorial)), 5);
-
-        $this->assertEquals($returnValue, $newReturnValue);
+        $this->assertSame(120, call_user_func($factorial, 5));
+        $this->assertSame(120, call_user_func(unserialize(serialize($factorial)), 5));
+        $this->assertSame(120, call_user_func(unserialize(serialize(unserialize(serialize($factorial)))), 5));
+        $this->assertSame(120, call_user_func(unserialize(serialize(unserialize(serialize(unserialize(serialize($factorial)))))), 5));
     }
 
     /**


### PR DESCRIPTION
This PR changes `SerializableClosure` to allow multiple serialize/unserialize runs without losing the state. The same behavior was possible with the previous, function parser based version so it merely fixes a regression.
