### PR TITLE
Explicitly requiring dev-master for php-parser

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "nikic/php-parser": "0.9.*@dev"
+        "nikic/php-parser": "dev-master"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*"


### PR DESCRIPTION
super_closure should explicitly require dev-master for php-parser, as as PHPParser_PrettyPrinter_Default is not available earlier.
