### PR TITLE
Add context-free code getter for ClosureParser

### DIFF
--- a/demo/context-free.php
+++ b/demo/context-free.php
@@ -1,0 +1,16 @@
+<?php
+
+require __DIR__ . '/../vendor/autoload.php';
+
+use Jeremeamia\SuperClosure\ClosureParser;
+
+$a = 42 * 2;
+$b = null;
+$c = ['hey', 123];
+$d = false;
+
+$parser = ClosureParser::fromClosure(function() use ($a, $b, $c, $d) {
+    return 42;
+});
+
+echo $parser->getContextFreeCode() . PHP_EOL;

--- a/src/Jeremeamia/SuperClosure/Visitor/ScalarValuesVisitor.php
+++ b/src/Jeremeamia/SuperClosure/Visitor/ScalarValuesVisitor.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Jeremeamia\SuperClosure\Visitor;
+
+/**
+ * Resolves scalar values (and arrays) passed through "use" statement
+ *
+ * @author Nikita Konstantinov
+ */
+final class ScalarValuesVisitor extends \PHPParser_NodeVisitorAbstract
+{
+    /**
+     * @var array
+     */
+    private $usedVariables;
+
+    /**
+     * @param \PHPParser_Node_Expr_ClosureUse[] $usedVariables
+     * @throws \InvalidArgumentException
+     */
+    public function __construct(array $usedVariables)
+    {
+        $this->usedVariables = $usedVariables;
+    }
+
+    public function beforeTraverse(array $nodes)
+    {
+        /** @var \PHPParser_Node_Expr_Closure $closureAst */
+        $closureAst = $nodes[0];
+
+        foreach ($closureAst->uses as $use) {
+            if ($use->byRef) {
+                throw new \InvalidArgumentException(sprintf('Variable "%s" is passed by ref', $use->var));
+            }
+        }
+
+        $closureAst->uses = array();
+
+        foreach ($this->usedVariables as $name => $value) {
+            array_unshift(
+                $closureAst->stmts,
+                new \PHPParser_Node_Expr_Assign(
+                    new \PHPParser_Node_Expr_Variable($name),
+                    $this->getNodeForValue($value)
+                )
+            );
+        }
+
+        return array($closureAst);
+    }
+
+    private function getNodeForValue($value)
+    {
+        switch (gettype($value)) {
+            case 'string':
+                return new \PHPParser_Node_Scalar_String($value);
+
+            case 'integer':
+                return new \PHPParser_Node_Scalar_LNumber($value);
+
+            case 'double':
+                return new \PHPParser_Node_Scalar_DNumber($value);
+
+            case 'boolean':
+                return new \PHPParser_Node_Expr_ConstFetch(
+                    new \PHPParser_Node_Name_FullyQualified($value ? 'true' : 'false')
+                );
+
+            case 'NULL':
+                return new \PHPParser_Node_Expr_ConstFetch(
+                    new \PHPParser_Node_Name_FullyQualified('null')
+                );
+
+            case 'array':
+                return new \PHPParser_Node_Expr_Array(
+                    array_map(array($this, 'getNodeForValue'), $value)
+                );
+        }
+
+        throw new \InvalidArgumentException('Only scalar values and arrays are allowed');
+    }
+} 

--- a/src/Jeremeamia/SuperClosure/Visitor/ThisVariableDetectorVisitor.php
+++ b/src/Jeremeamia/SuperClosure/Visitor/ThisVariableDetectorVisitor.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Jeremeamia\SuperClosure\Visitor;
+
+/**
+ * Detects if (closure's) AST contains $this variable
+ *
+ * @author Nikita Konstantinov
+ */
+final class ThisVariableDetectorVisitor extends \PHPParser_NodeVisitorAbstract
+{
+    private $detected = false;
+
+    public function leaveNode(\PHPParser_Node $node)
+    {
+        if ($node instanceof \PHPParser_Node_Expr_Variable) {
+            if ($node->name === 'this') {
+                $this->detected = true;
+            }
+        }
+    }
+
+    public function wasDetected()
+    {
+        return $this->detected;
+    }
+}

--- a/tests/Jeremeamia/SuperClosure/Test/Visitor/ScalarValuesVisitorTest.php
+++ b/tests/Jeremeamia/SuperClosure/Test/Visitor/ScalarValuesVisitorTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Jeremeamia\SuperClosure\Test\Visitor;
+
+use Jeremeamia\SuperClosure\Visitor\ScalarValuesVisitor;
+
+/**
+ * @covers Jeremeamia\SuperClosure\Visitor\ScalarValuesVisitor
+ */
+final class ScalarValuesVisitorTest extends \PHPUnit_Framework_TestCase
+{
+    public function testRemovingUseStatement()
+    {
+        $usedVars = array(
+            'a' => 42,
+            'b' => 3.14,
+            'c' => false,
+            'd' => null,
+            'e' => array('hey')
+        );
+
+        $detectorVisitor = new ScalarValuesVisitor($usedVars);
+
+        /** @var \PHPParser_Node_Expr_Closure[] $nodes */
+        $nodes = $detectorVisitor->beforeTraverse(
+            array(
+                new \PHPParser_Node_Expr_Closure(
+                    array(
+                        'uses' => array(
+                            new \PHPParser_Node_Expr_ClosureUse('a'),
+                            new \PHPParser_Node_Expr_ClosureUse('b'),
+                            new \PHPParser_Node_Expr_ClosureUse('c'),
+                            new \PHPParser_Node_Expr_ClosureUse('d'),
+                            new \PHPParser_Node_Expr_ClosureUse('e')
+                        )
+                    )
+                )
+            )
+        );
+
+        $expectedAst = new \PHPParser_Node_Expr_Closure(
+            array(
+                'stmts' => array(
+                    new \PHPParser_Node_Expr_Assign(
+                        new \PHPParser_Node_Expr_Variable('e'),
+                        new \PHPParser_Node_Expr_Array(array(new \PHPParser_Node_Scalar_String('hey')))
+                    ),
+                    new \PHPParser_Node_Expr_Assign(
+                        new \PHPParser_Node_Expr_Variable('d'),
+                        new \PHPParser_Node_Expr_ConstFetch(
+                            new \PHPParser_Node_Name_FullyQualified('null')
+                        )
+                    ),
+                    new \PHPParser_Node_Expr_Assign(
+                        new \PHPParser_Node_Expr_Variable('c'),
+                        new \PHPParser_Node_Expr_ConstFetch(
+                            new \PHPParser_Node_Name_FullyQualified('false')
+                        )
+                    ),
+                    new \PHPParser_Node_Expr_Assign(
+                        new \PHPParser_Node_Expr_Variable('b'),
+                        new \PHPParser_Node_Scalar_DNumber(3.14)
+                    ),
+                    new \PHPParser_Node_Expr_Assign(
+                        new \PHPParser_Node_Expr_Variable('a'),
+                        new \PHPParser_Node_Scalar_LNumber(42)
+                    ),
+                )
+            )
+        );
+
+        $this->assertEquals($expectedAst, $nodes[0]);
+    }
+}

--- a/tests/Jeremeamia/SuperClosure/Test/Visitor/ThisVariableDetectorVisitorTest.php
+++ b/tests/Jeremeamia/SuperClosure/Test/Visitor/ThisVariableDetectorVisitorTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jeremeamia\SuperClosure\Test\Visitor;
+
+use Jeremeamia\SuperClosure\Visitor\ThisVariableDetectorVisitor;
+
+/**
+ * @covers Jeremeamia\SuperClosure\Visitor\ThisVariableDetectorVisitor
+ */
+final class ThisVariableDetectorVisitorTest extends \PHPUnit_Framework_TestCase
+{
+    public function testPositiveAndNegativeCases()
+    {
+        $detectorVisitor = new ThisVariableDetectorVisitor();
+        $this->assertFalse($detectorVisitor->wasDetected());
+
+        $detectorVisitor->leaveNode(new \PHPParser_Node_Expr_Variable('foo'));
+        $this->assertFalse($detectorVisitor->wasDetected());
+
+        $detectorVisitor->leaveNode(new \PHPParser_Node_Expr_Variable('this'));
+        $this->assertTrue($detectorVisitor->wasDetected());
+    }
+}


### PR DESCRIPTION
Hi,

This PR adds "context-free" code getter, i.e. closure's code which doesn't depend on context via `$this` and `use (...)`. If it is not possible, getter raises `InvalidArgumentException`.

I suppose it could be useful in case of moving closure's code to somewhere like cache with assurance that we are able to move code without breaking something.

I'm not absolutely sure that it's OK, though.