### PR TITLE
Fixed bug when variable is null throwing undefined error

### DIFF
--- a/src/Jeremeamia/SuperClosure/ClosureParser.php
+++ b/src/Jeremeamia/SuperClosure/ClosureParser.php
@@ -150,7 +150,7 @@ class ClosureParser
             // Combine the two arrays to create a canonical hash of variable names and values
             $this->usedVariables = array();
             foreach ($usedVarNames as $name) {
-                if (isset($usedVarValues[$name])) {
+                if (array_key_exists($name, $usedVarValues)) {
                     $this->usedVariables[$name] = $usedVarValues[$name];
                 }
             }

--- a/tests/Jeremeamia/SuperClosure/Test/ClosureParserTest.php
+++ b/tests/Jeremeamia/SuperClosure/Test/ClosureParserTest.php
@@ -69,6 +69,21 @@ class ClosureParserTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers \Jeremeamia\SuperClosure\ClosureParser::getUsedVariables
+     */
+    public function testCanGetUsedVariablesWhenOneIsNullFromParser()
+    {
+        $foo = null;
+        $bar = 2;
+        $closure = function () use ($foo, $bar) {};
+        $expectedVars = array('foo' => null, 'bar' => 2);
+        $parser = new ClosureParser(new \ReflectionFunction($closure));
+        $actualVars = $parser->getUsedVariables();
+
+        $this->assertEquals($expectedVars, $actualVars);
+    }
+
+    /**
      * @covers \Jeremeamia\SuperClosure\ClosureParser::clearCache
      */
     public function testCanClearCache()


### PR DESCRIPTION
Fixes #23 - when an argument is null, it was originally throwing an undefined error due to the isset check. It is now returning the original null value.