### PR TITLE
Handle unserialization errors

### DIFF
--- a/src/Serializer.php
+++ b/src/Serializer.php
@@ -92,8 +92,17 @@ class Serializer implements SerializerInterface
             $this->verifySignature($signature, $serialized);
         }
 
-        /** @var SerializableClosure $unserialized */
+        set_error_handler(function () {});
         $unserialized = unserialize($serialized);
+        restore_error_handler();
+        if ($unserialized === false) {
+            throw new ClosureUnserializationException('The closure could not be unserialized');
+        } elseif (!$unserialized instanceof SerializableClosure) {
+            throw new ClosureUnserializationException(
+                'The closure did not unserialize to a SuperClosure. ' .
+                'Was it not serialized with SuperClosure\Serializer?'
+            );
+        }
 
         return $unserialized->getClosure();
     }

--- a/tests/Unit/SerializerTest.php
+++ b/tests/Unit/SerializerTest.php
@@ -34,6 +34,26 @@ class SerializerTest extends \PHPUnit_Framework_TestCase
         $serializer->unserialize($serializedFn);
     }
 
+    /**
+     * @expectedException \SuperClosure\Exception\ClosureUnserializationException
+     */
+    public function testUnserializingFailsWithInvalidData()
+    {
+        $serializer = new Serializer(new TokenAnalyzer());
+        $data = 'foobar' . serialize('foobar');
+        $serializer->unserialize($data);
+    }
+
+    /**
+     * @expectedException \SuperClosure\Exception\ClosureUnserializationException
+     */
+    public function testUnserializingFailsWhenSuperClosureIsNotReturned()
+    {
+        $serializer = new Serializer(new TokenAnalyzer());
+        $data = serialize('foobar');
+        $serializer->unserialize($data);
+    }
+
     public function testSerializingAndUnserializingWithSignature()
     {
         // Create a serializer with a signing key.


### PR DESCRIPTION
If `unserialize` fails or returns an object that isn't a `SuperClosure` PHP crashes with a fatal error with undefined method. This fixes that to just throw exception and not emit a notice.