### PR TITLE
Updated to use php-parser 2.0.0beta1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": ">=5.4",
-        "nikic/php-parser": "~1.2"
+        "nikic/php-parser": "^2.0@beta"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0",

--- a/src/Analyzer/AstAnalyzer.php
+++ b/src/Analyzer/AstAnalyzer.php
@@ -8,8 +8,7 @@ use PhpParser\NodeTraverser;
 use PhpParser\PrettyPrinter\Standard as NodePrinter;
 use PhpParser\Error as ParserError;
 use PhpParser\NodeVisitor\NameResolver;
-use PhpParser\Parser as CodeParser;
-use PhpParser\Lexer\Emulative as EmulativeLexer;
+use PhpParser\ParserFactory;
 
 /**
  * This is the AST based analyzer.
@@ -122,7 +121,7 @@ class AstAnalyzer extends ClosureAnalyzer
             );
         }
 
-        $parser = new CodeParser(new EmulativeLexer);
+        $parser = (new ParserFactory())->create(ParserFactory::PREFER_PHP7);
 
         return $parser->parse(file_get_contents($fileName));
     }


### PR DESCRIPTION
This PR updates SuperClosure to use 2.0.0beta1 of the PHP Parser.

Mainly because I'm interested in using SuperClosure in [Better Reflection](https://github.com/Roave/BetterReflection), but cannot as we are using the latest PHP Parser...

Naturally, you'll want to consider other things that depend on this (especially as it depends on a not-yet-stable dependency...) :smile: 