### PR TITLE
Allow use with php parser 2.x as well as 1.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": ">=5.4",
-        "nikic/php-parser": "~1.2"
+        "nikic/php-parser": "~1.2|~2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0|~5.0",

--- a/src/Analyzer/AstAnalyzer.php
+++ b/src/Analyzer/AstAnalyzer.php
@@ -9,6 +9,7 @@ use PhpParser\PrettyPrinter\Standard as NodePrinter;
 use PhpParser\Error as ParserError;
 use PhpParser\NodeVisitor\NameResolver;
 use PhpParser\Parser as CodeParser;
+use PhpParser\ParserFactory;
 use PhpParser\Lexer\Emulative as EmulativeLexer;
 
 /**
@@ -122,8 +123,19 @@ class AstAnalyzer extends ClosureAnalyzer
             );
         }
 
-        $parser = new CodeParser(new EmulativeLexer);
 
-        return $parser->parse(file_get_contents($fileName));
+        return $this->getParser()->parse(file_get_contents($fileName));
+    }
+
+    /**
+     * @return CodeParser
+     */
+    private function getParser()
+    {
+        if (class_exists('PhpParser\ParserFactory')) {
+            return (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
+        }
+
+        return new CodeParser(new EmulativeLexer);
     }
 }


### PR DESCRIPTION
I think it's good to remain compatible with both 1.x and 2.x for maximum compatibility with other packages and projects.

NB PHP Parser 2 is now at a beta stage rather than alpha, so it should be nearing a point of completion and API stability. The major advantage is that it adds full php 7 support.

--

// cc @asgrim