### PR TITLE
Unserialization fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .idea
-vendor
-build
+vendor/
+build/
 .DS_Store
 cache.properties
 composer.phar

--- a/Makefile
+++ b/Makefile
@@ -12,10 +12,6 @@ coverage:
 coverage-show:
 	open build/artifacts/coverage/index.html
 
-coverage-publish:
-	vendor/bin/phpunit --testsuite=unit --coverage-clover build/logs/clover.xml
-	CODECLIMATE_REPO_TOKEN=42ae1a885c6a20a0dc1c7802a3eb3a915b01f8f9c6f2443b8dd99ef77be48150 ./vendor/bin/test-reporter
-
 integ:
 	vendor/bin/phpunit --debug --testsuite=integ $(TEST)
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@
 [![Total Downloads](https://img.shields.io/packagist/dt/jeremeamia/superclosure.svg?style=flat)][1]
 [![Build Status](https://img.shields.io/travis/jeremeamia/super_closure/master.svg?style=flat)][2]
 [![MIT License](https://img.shields.io/packagist/l/jeremeamia/superclosure.svg?style=flat)][10]
-[![Code Climate](https://codeclimate.com/github/jeremeamia/super_closure/badges/gpa.svg)][11]
-[![GratiPay](http://img.shields.io/gratipay/jeremeamia.svg?style=flat)](https://www.gittip.com/jeremeamia)
 [![Gitter](https://badges.gitter.im/Join Chat.svg)](https://gitter.im/jeremeamia/super_closure)
 
 A PHP Library for serializing closures and anonymous functions.
@@ -157,7 +155,8 @@ should _choose the fastest analyzer that supports the features you need_.
   opening yourself up to code injection attacks. It is a good idea sign
   serialized closures if you plan on storing or transporting them. Read the
   **Signing Closures** section below for details on how to do this.
-4. Cannot serialize closures that are defined within `eval()`'d code.
+4. Cannot serialize closures that are defined within `eval()`'d code. This
+  includes re-serializing a closure that has been unserialized. 
 
 ### Analyzers
 
@@ -285,6 +284,12 @@ about the 7:50 mark they show how you can push a closure onto a queue as a job
 so that it can be executed by a worker. This is nice because you do not have to
 create a whole class for a job that might be really simple.
 
+Or... you might have a dependency injection container or router object that is
+built by writing closures. If you wanted to cache that, you would need to be
+able to serialize it.
+
+In general, however, serializing closures should probably be avoided.
+
 ## Tell me about how this project started
 
 It all started  back in the beginning of 2010 when PHP 5.3 was starting to
@@ -309,6 +314,12 @@ iterations have been more robust, thanks to the usage of the fabulous
 - [florianv/business](https://github.com/florianv/business) - Serializes special days to store business days definitions.
 - Please let me know if and how your project uses Super Closure.
 
+## Alternatives
+
+This year the [Opis Closure][11] library has been introduced, that also provides
+the ability to serialize a closure. You should check it out as well and see
+which one suits your needs the best.
+
 [1]:  https://packagist.org/packages/jeremeamia/superclosure
 [2]:  https://travis-ci.org/jeremeamia/super_closure
 [3]:  http://packagist.org/packages/jeremeamia/SuperClosure
@@ -319,4 +330,4 @@ iterations have been more robust, thanks to the usage of the fabulous
 [8]:  http://vimeo.com/64703617
 [9]:  http://www.userscape.com
 [10]: https://github.com/jeremeamia/super_closure/blob/master/LICENSE.md
-[11]: https://codeclimate.com/github/jeremeamia/super_closure
+[11]: https://github.com/opis/closure

--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,7 @@
         "nikic/php-parser": "~1.2|~2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.0|~5.0",
-        "codeclimate/php-test-reporter": "~0.1.2"
+        "phpunit/phpunit": "~4.0|~5.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/SerializableClosure.php
+++ b/src/SerializableClosure.php
@@ -209,8 +209,8 @@ function __reconstruct_closure(array $__data)
         } else {
             @eval("\$__closure = {$__data['code']};");
         }
-    } catch (\ParseException $e) {
-        // Discard the parse exception.
+    } catch (\ParseError $e) {
+        // Discard the parse error.
     }
 
     return isset($__closure) ? $__closure : null;

--- a/tests/Integ/SerializationTest.php
+++ b/tests/Integ/SerializationTest.php
@@ -122,7 +122,7 @@ class SerializationTest extends \PHPUnit_Framework_TestCase
         $foo = new Foo(10);
         $closure = $foo->getClosure();
 
-        $results = $this->getResults($closure, [], true);
+        $results = $this->getResults($closure, []);
         $this->assertAllEquals(10, $results);
     }
 
@@ -142,14 +142,26 @@ class SerializationTest extends \PHPUnit_Framework_TestCase
             return 10;
         };
 
-        $results = $this->getResults($closure, [], true);
+        $results = $this->getResults($closure, []);
         $this->assertAllEquals(10, $results);
+    }
+
+    public function testClosuresInContextAreUnboxedBackToClosures()
+    {
+        $usedFn = function () {};
+        $closure = function () use ($usedFn){
+            return get_class($usedFn);
+        };
+
+        $results = $this->getResults($closure, []);
+        $this->assertAllEquals('Closure', $results);
     }
 
     private function getResults(\Closure $closure, array $args = [])
     {
         $results = ['original' => call_user_func_array($closure, $args)];
 
+        // AST
         try {
             $serializer = new Serializer(new AstAnalyzer, 'hashkey');
             $serialized = $serializer->serialize($closure);
@@ -161,6 +173,7 @@ class SerializationTest extends \PHPUnit_Framework_TestCase
             $results['ast'] = 'ERROR';
         }
 
+        // Token
         try {
             $serializer = new Serializer(new TokenAnalyzer, 'hashkey');
             $serialized = $serializer->serialize($closure);


### PR DESCRIPTION
- Reconstructs closures in a "private" function, outside of the `SerializableClosure` class, in order to have a neutral binding and scope. Fixes some edge cases with bindings and static closures.
- Updates unserialization logic to unbox closures that are in _used_ variables.

Review: @GrahamCampbell