### PR TITLE
Identify failed serialization with signature option

### DIFF
--- a/src/Exception/ClosureSerializationException.php
+++ b/src/Exception/ClosureSerializationException.php
@@ -1,0 +1,8 @@
+<?php namespace SuperClosure\Exception;
+/**
+ * This exception is thrown when there is a problem serializing a closure.
+ */
+class ClosureSerializationException extends \RuntimeException implements SuperClosureException
+{
+    //
+}

--- a/src/Serializer.php
+++ b/src/Serializer.php
@@ -67,7 +67,7 @@ class Serializer implements SerializerInterface
     {
         $serialized = serialize(new SerializableClosure($closure, $this));
 
-        if ($this->signingKey) {
+        if (($serialized !== null) && $this->signingKey) {
             $signature = $this->calculateSignature($serialized);
             $serialized = '%' . base64_encode($signature) . $serialized;
         }

--- a/src/Serializer.php
+++ b/src/Serializer.php
@@ -2,6 +2,7 @@
 
 use SuperClosure\Analyzer\AstAnalyzer as DefaultAnalyzer;
 use SuperClosure\Analyzer\ClosureAnalyzer;
+use SuperClosure\Exception\ClosureSerializationException;
 use SuperClosure\Exception\ClosureUnserializationException;
 
 /**
@@ -66,8 +67,14 @@ class Serializer implements SerializerInterface
     public function serialize(\Closure $closure)
     {
         $serialized = serialize(new SerializableClosure($closure, $this));
+        
+        if ($serialized === null) {
+            throw new ClosureSerializationException(
+                'The closure could not be serialized.'
+            );
+        }
 
-        if (($serialized !== null) && $this->signingKey) {
+        if ($this->signingKey) {
             $signature = $this->calculateSignature($serialized);
             $serialized = '%' . base64_encode($signature) . $serialized;
         }


### PR DESCRIPTION
In order to identify that serialization has failed, even with signature option, may I suggest not adding a signature if serialization of closure fails, and return the original `null` value returned by `serialize()`.