### PR TITLE
fixed error for "${" appear in closure body.

### DIFF
--- a/src/Analyzer/TokenAnalyzer.php
+++ b/src/Analyzer/TokenAnalyzer.php
@@ -55,7 +55,7 @@ class TokenAnalyzer extends ClosureAnalyzer
                 // Handle tokens inside the function body.
                 case 2:
                     $data['tokens'][] = $token;
-                    if ($token->is('{')) {
+                    if ($token->is('{') || $token->is('${')) {
                         $braceLevel++;
                     } elseif ($token->is('}')) {
                         $braceLevel--;

--- a/tests/Unit/Analyzer/TokenAnalyzerTest.php
+++ b/tests/Unit/Analyzer/TokenAnalyzerTest.php
@@ -1,0 +1,66 @@
+<?php namespace SuperClosure\Test\Unit\Analyzer;
+
+use SuperClosure\Serializer;
+use SuperClosure\Analyzer\TokenAnalyzer;
+
+class TokenAnalyzerTest extends \PHPUnit_Framework_TestCase
+{
+    public function testDollarOpenCurlyBraces()
+    {
+        $greeting = 'hello';
+        $hello = function ($name = 'world') use ($greeting) {
+            return "{$greeting}, {$name}";
+        };
+        $unserialized = $this->prepareOpenCurlyBracesTest($hello);
+
+        $this->assertEquals('hello, world', $unserialized());
+        $this->assertEquals('hello, user', $unserialized('user'));
+    }
+
+    public function testAnotherStyleDollarOpenCurlyBraces()
+    {
+        $greeting = 'hello';
+        $hello = function ($name = 'world') use ($greeting) {
+            return "${greeting}, ${name}";
+        };
+        $unserialized = $this->prepareOpenCurlyBracesTest($hello);
+
+        $this->assertEquals('hello, world', $unserialized());
+        $this->assertEquals('hello, user', $unserialized('user'));
+    }
+
+    public function testDollarOpenCurlyBracesWithFunctions()
+    {
+        $greeting = 'hello';
+        $hello = function ($name = 'world') use ($greeting) {
+            return "{$greeting}, {${$this->getOpenCurlyBracesTestArgument()}}";
+        };
+        $unserialized = $this->prepareOpenCurlyBracesTest($hello);
+
+        $this->assertEquals('hello, world', $unserialized());
+    }
+
+    public function testSimplerDollarOpenCurlyBracesWithFunctions()
+    {
+        $greeting = 'hello';
+        $hello = function ($name = 'world') use ($greeting) {
+            return "${greeting}, ${$this->getOpenCurlyBracesTestArgument()}";
+        };
+        $unserialized = $this->prepareOpenCurlyBracesTest($hello);
+
+        $this->assertEquals('hello, world', $unserialized());
+    }
+
+    private function getOpenCurlyBracesTestArgument()
+    {
+        return 'name';
+    }
+
+    private function prepareOpenCurlyBracesTest(\Closure $closure)
+    {
+        $serializer = new Serializer(new TokenAnalyzer());
+        $serialized = $serializer->serialize($closure);
+
+        return $serializer->unserialize($serialized);
+    }
+}


### PR DESCRIPTION
when a closure like this

```php
<?php
$hello = function ($name = 'world') {
    echo "${name}";
}
```
it will be unserialize failed.