### PR TITLE
Suggest brick/varexporter in alternatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,8 @@ This year the [Opis Closure][11] library has been introduced, that also provides
 the ability to serialize a closure. You should check it out as well and see
 which one suits your needs the best.
 
+If you wish to export your closures as executable PHP code instead, you can check out the [brick/varexporter][12] library.
+
 [1]:  https://packagist.org/packages/jeremeamia/superclosure
 [2]:  https://travis-ci.org/jeremeamia/super_closure
 [3]:  http://packagist.org/packages/jeremeamia/SuperClosure
@@ -333,3 +335,4 @@ which one suits your needs the best.
 [9]:  http://www.userscape.com
 [10]: https://github.com/jeremeamia/super_closure/blob/master/LICENSE.md
 [11]: https://github.com/opis/closure
+[12]: https://github.com/brick/varexporter


### PR DESCRIPTION
Hi, first of all thank you for bringing us SuperClosure! It inspired me to write a userland implementation of `var_export()`, that can export closures as well:

https://github.com/brick/varexporter

Just like SuperClosure, it's based on nikic's PHP-Parser library, and works pretty well, with a few [caveats](https://github.com/brick/varexporter#caveats).

Would you be willing to add a link to it in the Alternatives section of the README?

Cheers!
Ben