### PR TITLE
Fix char / string

### DIFF
--- a/tests/Unit/SerializerTest.php
+++ b/tests/Unit/SerializerTest.php
@@ -27,7 +27,7 @@ class SerializerTest extends \PHPUnit_Framework_TestCase
         $serializedFn = $serializer->serialize($originalFn);
 
         // Modify the serialized closure.
-        $serializedFn[5] = '6119dcd1245df749d162b544d4f44280eef3e7f4d4c636611ed87e7b97198c0b';
+        $serializedFn[5] = 'x';
 
         // Unserialization should fail on invalid signature.
         $this->setExpectedException('SuperClosure\Exception\ClosureUnserializationException');


### PR DESCRIPTION
Using PHP 8

```
1) SuperClosure\Test\Unit\SerializerTest::testUnserializingFailsWithInvalidSignature
Only the first byte will be assigned to the string offset

/dev/shm/BUILD/super_closure-5707d5821b30b9a07acfb4d76949784aaa0e9ce9/tests/Unit/SerializerTest.php:30

```