### PR TITLE
Add serializer into SerializableClosure when inserialize

### DIFF
--- a/src/SerializableClosure.php
+++ b/src/SerializableClosure.php
@@ -109,6 +109,8 @@ class SerializableClosure implements \Serializable
     {
         try {
             $this->data = $this->data ?: $this->serializer->getData($this->closure, true);
+            $this->serializer = new Serializer;
+
             return serialize($this->data);
         } catch (\Exception $e) {
             trigger_error(


### PR DESCRIPTION
This PR adding serializer into SerializableClosure after unserializing. I think this is convinient to get serializer back into property in case testing, when serializing and deserializing composite objects, because without it you will get error of comparing old and new structure (see screenshots)
![image](https://github.com/jeremeamia/super_closure/assets/41924972/29ca54ee-515a-4597-8d78-e003f49f59c3)
![image](https://github.com/jeremeamia/super_closure/assets/41924972/34079117-31a9-48b8-80c5-34f321864873)

